### PR TITLE
# Fix Node Allocation for Summer Campaign Presets

### DIFF
--- a/campaigns/cosmosim-mocks-2025.yaml
+++ b/campaigns/cosmosim-mocks-2025.yaml
@@ -41,7 +41,7 @@ variants:
   # VALIDATION RUNS (Priority 100-89) - Submit immediately for testing
   - name: "lcdm-validation"
     cosmology: "flagship-lcdm"
-    resolution: "flagship-validation"
+    resolution: "summer-validation"
     priority: 100
     dependencies: []
     submission_deadline: "2025-06-10T23:59:59"
@@ -52,7 +52,7 @@ variants:
       
   - name: "wcdm-validation"
     cosmology: "flagship-wcdm"
-    resolution: "flagship-validation"
+    resolution: "summer-validation"
     priority: 95
     dependencies: ["lcdm-validation"]
     submission_deadline: "2025-06-12T23:59:59"
@@ -63,7 +63,7 @@ variants:
       
   - name: "phicdm-validation"
     cosmology: "flagship-phicdm"
-    resolution: "flagship-validation"
+    resolution: "summer-validation"
     priority: 90
     dependencies: ["wcdm-validation"]
     submission_deadline: "2025-06-14T23:59:59"
@@ -75,7 +75,7 @@ variants:
   # SCALING TESTS (Priority 89-80) - Submit after validation completes
   - name: "lcdm-scaling"
     cosmology: "flagship-lcdm"
-    resolution: "flagship-scaling"
+    resolution: "summer-scaling-2800"
     priority: 85
     dependencies: ["lcdm-validation"]
     submission_deadline: "2025-06-20T23:59:59"
@@ -87,7 +87,7 @@ variants:
   # PRODUCTION RUNS (Priority 79-70) - Critical for July 1 deadline
   - name: "lcdm-production"
     cosmology: "flagship-lcdm"
-    resolution: "flagship-production"
+    resolution: "summer-production"
     priority: 79
     dependencies: ["lcdm-scaling"]
     submission_deadline: "2025-06-28T23:59:59"
@@ -98,7 +98,7 @@ variants:
       
   - name: "wcdm-production"
     cosmology: "flagship-wcdm"
-    resolution: "flagship-production"
+    resolution: "summer-production"
     priority: 75
     dependencies: ["lcdm-production"]
     submission_deadline: "2025-06-30T23:59:59"
@@ -110,7 +110,7 @@ variants:
   # EXTENDED ANALYSIS (Priority 69-60) - Submit after production if resources allow
   - name: "phicdm-production"
     cosmology: "flagship-phicdm"
-    resolution: "flagship-production"
+    resolution: "summer-production"
     priority: 65
     dependencies: ["wcdm-production"]
     submission_deadline: "2025-07-05T23:59:59"

--- a/pkdpipe/config.py
+++ b/pkdpipe/config.py
@@ -86,10 +86,11 @@ SIMULATION_PRESETS = {
     },
     
     # Campaign-specific presets for summer multi-cosmology campaigns
+    # Node allocation follows scaling law: N = 2 * (nGrid/1400)^3
     "summer-validation": {
         "dBoxSize": 1050,
         "nGrid": 1400,
-        "nodes": 50,
+        "nodes": 2,  # Updated: 2 * (1400/1400)^3 = 2 * 1 = 2
         "gpupern": 4,
         "tlimit": "12:00:00",
         "comment": "Validation resolution for campaign testing",
@@ -97,7 +98,7 @@ SIMULATION_PRESETS = {
     "summer-production": {
         "dBoxSize": 5250,
         "nGrid": 7000,
-        "nodes": 250,
+        "nodes": 250,  # Correct: 2 * (7000/1400)^3 = 2 * 125 = 250
         "gpupern": 4,
         "tlimit": "48:00:00",
         "comment": "Full summer resolution for production simulations",
@@ -105,7 +106,7 @@ SIMULATION_PRESETS = {
     "summer-scaling-2800": {
         "dBoxSize": 2100,
         "nGrid": 2800,
-        "nodes": 64,
+        "nodes": 16,  # Updated: 2 * (2800/1400)^3 = 2 * 8 = 16
         "gpupern": 4,
         "tlimit": "24:00:00",
         "comment": "LCDM scaling test with 2800³ grid",
@@ -113,7 +114,7 @@ SIMULATION_PRESETS = {
     "summer-scaling-4200": {
         "dBoxSize": 3150,
         "nGrid": 4200,
-        "nodes": 144,
+        "nodes": 54,  # Updated: 2 * (4200/1400)^3 = 2 * 27 = 54
         "gpupern": 4,
         "tlimit": "36:00:00",
         "comment": "LCDM scaling test with 4200³ grid",
@@ -291,4 +292,3 @@ class TemplateError(PkdpipeConfigError):
 class JobSubmissionError(PkdpipeConfigError):
     """Exception raised for errors during job submission."""
     pass
-


### PR DESCRIPTION

## Overview

This PR corrects the node allocation calculations for summer campaign simulation presets and updates the cosmosim-mocks-2025 campaign configuration to use the proper summer-specific presets.

## Changes Made

### 1. Configuration Updates (`pkdpipe/config.py`)

Fixed node allocation for summer campaign presets to follow the correct scaling law: `N = 2 * (nGrid/1400)³`

- **`summer-validation`**: Corrected from 50 to **2 nodes** (2 × (1400/1400)³ = 2)
- **`summer-scaling-2800`**: Corrected from 64 to **16 nodes** (2 × (2800/1400)³ = 16)  
- **`summer-scaling-4200`**: Corrected from 144 to **54 nodes** (2 × (4200/1400)³ = 54)
- **`summer-production`**: Confirmed correct at **250 nodes** (2 × (7000/1400)³ = 250)

Added documentation comment explaining the scaling law formula for future reference.

### 2. Campaign Configuration (`campaigns/cosmosim-mocks-2025.yaml`)

Updated all simulation variants to use the appropriate summer-specific presets:

- **Validation runs**: Changed from `flagship-validation` to `summer-validation`
- **Scaling tests**: Changed from `flagship-scaling` to `summer-scaling-2800`  
- **Production runs**: Changed from `flagship-production` to `summer-production`

## Impact

- **Resource Efficiency**: Significantly reduces node allocation for validation and scaling tests, preventing over-allocation of compute resources
- **Campaign Alignment**: Ensures the 2025 cosmosim campaign uses the intended summer-specific configurations
- **Cost Optimization**: Proper node allocation will reduce unnecessary compute costs, especially for validation runs

## Testing Considerations

- Validation runs should be submitted first to verify the corrected node allocations work properly
- Monitor job performance to ensure the reduced node counts still provide adequate computational resources
- Scaling tests will validate performance across different grid sizes with the new allocations

## Files Modified

- `pkdpipe/config.py` - Node allocation corrections and documentation
- `campaigns/cosmosim-mocks-2025.yaml` - Campaign preset updates